### PR TITLE
Add support for namespaced structs

### DIFF
--- a/test/fixtures/billing_account_encoded.json
+++ b/test/fixtures/billing_account_encoded.json
@@ -1,0 +1,33 @@
+{
+  "billingAddress": {
+    "city": "Hill Valley, CA",
+    "country": {
+      "code": "us",
+      "name": "United States of America"
+    },
+    "postCode": "90999",
+    "streetAddressLineOne": "1640 Riverside Drive"
+  },
+  "contactEmail": "contact@somecompany.com",
+  "contactName": "Some Company",
+  "id": "a:b-1",
+  "latestInvoice": {
+    "dueDate": "2023-01-31",
+    "items": [
+      {
+        "name": "Video Game",
+        "quantity": 1,
+        "subtotal": 60.0,
+        "unitPrice": 60.0
+      },
+      {
+        "name": "Another Video Game",
+        "quantity": 1,
+        "subtotal": 19.99,
+        "unitPrice": 19.99
+      }
+    ],
+    "period": "01/23",
+    "subtotal": 79.99
+  }
+}

--- a/test/jason_structs/decoder_test.exs
+++ b/test/jason_structs/decoder_test.exs
@@ -11,6 +11,20 @@ defmodule Jason.Structs.DecoderTest do
     assert user == DummyData.user()
   end
 
+  test "decodes a JSON into a Jason struct with namespaced substructs" do
+    {:ok, json} = File.read("test/fixtures/billing_account_encoded.json")
+
+    # make sure that the modules are loaded so we don't run into issues with
+    # :erlang.binary_to_existing_atom during parse
+    Code.ensure_loaded!(Billing.Account)
+    Code.ensure_loaded!(Billing.Invoice)
+    Code.ensure_loaded!(Billing.InvoiceItem)
+
+    {:ok, account} = Decoder.decode(json, Billing.Account)
+
+    assert account == DummyData.billing_account()
+  end
+
   test "decodes a JSON into a map if a struct is not passed" do
     {:ok, json} = File.read("test/fixtures/pesho_encoded.json")
 

--- a/test/jason_structs/encoder_test.exs
+++ b/test/jason_structs/encoder_test.exs
@@ -2,13 +2,23 @@ defmodule Jason.Structs.EncoderTest do
   use ExUnit.Case
 
   setup do
-    {:ok, %{user: DummyData.user()}}
+    {:ok, %{user: DummyData.user(), billing_account: DummyData.billing_account()}}
   end
 
   test "encodes a Jason struct into valid JSON", %{user: user} do
     {:ok, encoded} = Jason.Structs.encode(user, pretty: true)
 
     {:ok, expected} = File.read("test/fixtures/pesho_encoded.json")
+
+    assert encoded == String.trim(expected)
+  end
+
+  test "encodes a Jason struct with namespaced substructs into valid JSON", %{
+    billing_account: billing_account
+  } do
+    {:ok, encoded} = Jason.Structs.encode(billing_account, pretty: true)
+
+    {:ok, expected} = File.read("test/fixtures/billing_account_encoded.json")
 
     assert encoded == String.trim(expected)
   end

--- a/test/support/dummy_data.ex
+++ b/test/support/dummy_data.ex
@@ -48,4 +48,44 @@ defmodule DummyData do
       likes_json_structs: false
     }
   end
+
+  def invoice do
+    %Billing.Invoice{
+      period: "01/23",
+      due_date: "2023-01-31",
+      items: [
+        %Billing.InvoiceItem{
+          name: "Video Game",
+          unit_price: 60.0,
+          quantity: 1,
+          subtotal: 60.0,
+        },
+        %Billing.InvoiceItem{
+          name: "Another Video Game",
+          unit_price: 19.99,
+          quantity: 1,
+          subtotal: 19.99,
+        }
+      ],
+      subtotal: 79.99
+    }
+  end
+
+  def billing_account do
+    %Billing.Account{
+      id: "a:b-1",
+      contact_name: "Some Company",
+      contact_email: "contact@somecompany.com",
+      billing_address: %Address{
+        city: "Hill Valley, CA",
+        street_address_line_one: "1640 Riverside Drive",
+        post_code: "90999",
+        country: %Country{
+          code: "us",
+          name: "United States of America"
+        }
+      },
+      latest_invoice: invoice()
+    }
+  end
 end

--- a/test/support/structs.ex
+++ b/test/support/structs.ex
@@ -41,3 +41,43 @@ defmodule User do
     field(:likes_json_structs, boolean(), default: true)
   end
 end
+
+defmodule Billing do
+  defmodule InvoiceItem do
+    use Jason.Structs.Struct
+
+    jason_struct do
+      field(:name, String.t(), enforce: true)
+      field(:quantity, float(), enforce: true)
+      field(:unit_price, float(), enforce: true)
+      field(:subtotal, float(), enforce: true)
+    end
+  end
+
+  defmodule Invoice do
+    use Jason.Structs.Struct
+
+    alias Billing.InvoiceItem, as: Item
+
+    jason_struct do
+      field(:period, String.t(), enforce: true)
+      field(:due_date, String.t(), enforce: true)
+      field(:items, [Item.t()], enforce: true)
+      field(:subtotal, float(), enforce: true)
+    end
+  end
+
+  defmodule Account do
+    use Jason.Structs.Struct
+
+    alias Billing.Invoice
+
+    jason_struct do
+      field(:id, String.t(), enforce: true)
+      field(:contact_name, String.t(), enforce: true)
+      field(:contact_email, String.t(), enforce: true)
+      field(:billing_address, Address.t(), enforce: true)
+      field(:latest_invoice, Invoice.t(), enforce: true)
+    end
+  end
+end


### PR DESCRIPTION
Hey, thanks for creating this library! As a newcomer to Elixir it's been quite useful for figuring out how things work in general, and it's now an integral part of an API client that I'm currently building.

When building the client, however, I realized that we weren't able to specify namespaced structs like `Foo.Bar.t()` otherwise the compiler would complain about `Foo.Bar.t()` not being a function. Neither aliasing and/or importing `Foo.Bar` and using `Bar.t()`, nor creating a typespec like `@type foo_bar :: Foo.Bar.t()` and using `foo_bar()` in the `field()` call helped.

Since I think namespacing is an important aspect of code organization and one would assume they would be able to do `Foo.Bar.t()` to reference namespaced structs (which I certainly did 😃), I decided to make a few changes.

With the full module paths being captured now, as well as aliases being resolved to full module paths during `field()` calls, users are now free to use`Foo.Bar.t()`, do `alias Foo.Bar` and `Bar.t()`, or `alias Foo.Bar, as: SomeOtherBar` and `SomeOtherBar.t()`.

Please see the test cases in the codebase for an actual example.

By the way I have some additional features that I think would improve the overall developer experience when building with this tool (e.g. optional support for `String.to_atom`, capturing default options like `jason_struct enforce: false do`), so would you want me to open individual issues for each suggestion, or don't mind if I open a PR with all of the changes? Thanks!